### PR TITLE
docs: expand "Listed on" with verified directory and tracker listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,9 +355,12 @@ claude-wave-plugin/
 
 ## Listed on
 
-- [Flowy](https://www.flowy.sh/listings/harshvardhan86-claude-wave-plugin) — plugin directory entry with skills, commands and repo listed
-- [Vibed Lab Plugins](https://plugins.vibed-lab.com/plugin/harshvardhan86-claude-wave-plugin) — weekly-curated Claude Code plugin directory listing
-- [MCP Market](https://mcpmarket.com/tools/skills/brutal-acceptance-criteria-writer) — skill listing for `ac-writer`, the brutal acceptance criteria phase
+- [Flowy](https://www.flowy.sh/listings/harshvardhan86-claude-wave-plugin) — plugin directory entry listing skills, commands, and repo
+- [Vibed Lab Plugins](https://plugins.vibed-lab.com/plugin/harshvardhan86-claude-wave-plugin) — curated Claude Code plugin directory
+- [MCP Market](https://mcpmarket.com/tools/skills/wave-orchestrator) — lists all seven skills individually, e.g. ac-writer as "Brutal Acceptance Criteria Writer"
+- [Skills Directory](https://www.skillsdirectory.com/skills?author=Harshvardhan86) — all seven skills listed with `npx skills add` install commands
+- [SkillsMP](https://skillsmp.com/creators/harshvardhan86) — creator page listing the plugin's seven skills
+- [Claude Code Insights](https://zhoux77899.github.io/claude-code-insights/) — daily-updated tracker of active Claude Code repositories
 
 ## Used in production by
 


### PR DESCRIPTION
## Summary

Expands the README's "Listed on" section from the three listings found first to six, one line per site. Every entry was verified by reading the page itself and confirming it names this repository, its author, or one of its own skills.

- Flowy — plugin directory entry
- Vibed Lab Plugins — curated plugin directory
- MCP Market — all seven skills listed individually (linked from the wave-orchestrator page)
- Skills Directory — author page with `npx skills add` install commands for all seven skills
- SkillsMP — creator page listing the plugin's seven skills
- Claude Code Insights — daily-updated tracker of active Claude Code repositories

Left out on purpose: a cached listing whose live page is gone, and directories that could not be read without sign-up or behind bot-checks.

README content tests: `bash tests/run.sh --filter 'docs-*'` → 6 passed, 0 failed.